### PR TITLE
removing unnecessary flex style

### DIFF
--- a/style.css
+++ b/style.css
@@ -265,11 +265,6 @@ body {
 	margin: 0;
 }
 body {
-	display: -webkit-box;
-	display: -moz-box;
-	display: -ms-flexbox;
-	display: -webkit-flex;
-	display: flex;
 	background: #fff;
 	border-top: 6px solid #45ac9d;
 	color: #3b3b3b;


### PR DESCRIPTION
Removing the flex style from body doesn't seem to cause harm to other pages, so I vote remove. I can push through changes to the other branches and revised the styles downloaded in the "fancy-up-the-header-and-footer-sections-of-your-site" challenge.