### PR TITLE
Comment form line-height changed from 3 to 2em

### DIFF
--- a/style.css
+++ b/style.css
@@ -706,7 +706,7 @@ body {
 }
 .comment-form input {
 	width: 100%;
-	line-height: 3em;
+	line-height: 2em;
 	text-indent: 1em;
 	border: 1px solid #BFBFBF;
 }


### PR DESCRIPTION
Fixes an issue on iOS devices where text written into the Name and Email fields  of comment forms are being forced under the input field by line-height.